### PR TITLE
Feat/login : 로그인 페이지 퍼플리싱 추가

### DIFF
--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const LoginPage = () => {
-  return <div>LoginPage</div>;
+  return <div>LoginPage 변경사항</div>;
 };
 
 export default LoginPage;

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -1,7 +1,304 @@
-import React from "react";
+import React, { useState } from "react";
+import {
+  Container,
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Link,
+  Divider,
+  Paper,
+  IconButton,
+  InputAdornment,
+  Alert,
+} from "@mui/material";
+import {
+  Visibility,
+  VisibilityOff,
+  MenuBook,
+  ArrowBack,
+} from "@mui/icons-material";
+import { useNavigate } from "react-router-dom";
+import { styled } from "@mui/material/styles";
 
 const LoginPage = () => {
-  return <div>LoginPage 변경사항</div>;
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [errors, setErrors] = useState({});
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    // 에러 메시지 제거
+    if (errors[name]) {
+      setErrors((prev) => ({
+        ...prev,
+        [name]: "",
+      }));
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const newErrors = {};
+
+    if (!formData.email) {
+      newErrors.email = "이메일을 입력해주세요";
+    } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
+      newErrors.email = "올바른 이메일 형식을 입력해주세요";
+    }
+
+    if (!formData.password) {
+      newErrors.password = "비밀번호를 입력해주세요";
+    } else if (formData.password.length < 6) {
+      newErrors.password = "비밀번호는 최소 6자 이상이어야 합니다";
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    // TODO: 로그인 로직 구현
+    console.log("로그인 시도:", formData);
+  };
+
+  const handleBackToHome = () => {
+    navigate("/");
+  };
+
+  return (
+    <PageContainer>
+      <Container maxWidth="sm">
+        {/* 뒤로가기 버튼 */}
+        <Box sx={{ mb: 3, textAlign: "left" }}>
+          <BackButton startIcon={<ArrowBack />} onClick={handleBackToHome}>
+            홈으로 돌아가기
+          </BackButton>
+        </Box>
+
+        {/* 로고 및 제목 */}
+        <Box sx={{ textAlign: "center", mb: 4 }}>
+          <LogoContainer>
+            <MenuBook sx={{ fontSize: 40, color: "white" }} />
+          </LogoContainer>
+          <MainTitle variant="h3" component="h1">
+            AIary
+          </MainTitle>
+          <Subtitle variant="h6">
+            영어 일기로 시작하는 자연스러운 영어 학습
+          </Subtitle>
+        </Box>
+
+        {/* 로그인 폼 */}
+        <FormContainer elevation={8}>
+          <FormTitle variant="h4" component="h2">
+            다시 오신 것을 환영합니다
+          </FormTitle>
+          <FormDescription variant="body1">
+            영어 학습 여정을 계속 이어가보세요
+          </FormDescription>
+
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <StyledTextField
+              fullWidth
+              label="이메일"
+              name="email"
+              type="email"
+              value={formData.email}
+              onChange={handleChange}
+              error={!!errors.email}
+              helperText={errors.email}
+              placeholder="이메일을 입력해주세요"
+            />
+
+            <StyledTextField
+              fullWidth
+              label="비밀번호"
+              name="password"
+              type={showPassword ? "text" : "password"}
+              value={formData.password}
+              onChange={handleChange}
+              error={!!errors.password}
+              helperText={errors.password}
+              placeholder="비밀번호를 입력해주세요"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      onClick={() => setShowPassword(!showPassword)}
+                      edge="end"
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            <LoginButton
+              type="submit"
+              fullWidth
+              variant="contained"
+              size="large"
+            >
+              로그인
+            </LoginButton>
+
+            <Box sx={{ textAlign: "center", mb: 3 }}>
+              <ForgotPasswordLink href="#">
+                비밀번호를 잊으셨나요?
+              </ForgotPasswordLink>
+            </Box>
+
+            <Divider sx={{ my: 3 }}>
+              <DividerText variant="body2">처음이신가요?</DividerText>
+            </Divider>
+
+            <RegisterButton
+              fullWidth
+              variant="outlined"
+              size="large"
+              onClick={() => navigate("/register")}
+            >
+              계정 만들기
+            </RegisterButton>
+          </Box>
+        </FormContainer>
+      </Container>
+    </PageContainer>
+  );
 };
 
 export default LoginPage;
+
+// 스타일드 컴포넌트들
+const PageContainer = styled(Box)({
+  minHeight: "100vh",
+  background: "linear-gradient(135deg, #f8fffe 0%, #e8f5e8 100%)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "32px 0",
+});
+
+const BackButton = styled(Button)({
+  color: "var(--app-chart-1)",
+  "&:hover": {
+    backgroundColor: "rgba(96, 175, 160, 0.1)",
+  },
+});
+
+const LogoContainer = styled(Box)({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 80,
+  height: 80,
+  borderRadius: "50%",
+  backgroundColor: "var(--app-chart-1)",
+  marginBottom: 16,
+  boxShadow: "0 4px 20px rgba(96, 175, 160, 0.3)",
+});
+
+const MainTitle = styled(Typography)({
+  fontWeight: 700,
+  color: "var(--app-chart-1)",
+  marginBottom: 8,
+});
+
+const Subtitle = styled(Typography)({
+  color: "var(--app-muted-fg)",
+  fontWeight: 400,
+});
+
+const FormContainer = styled(Paper)({
+  padding: 32,
+  borderRadius: 24,
+  backgroundColor: "white",
+  boxShadow: "0 8px 32px rgba(96, 175, 160, 0.15)",
+});
+
+const FormTitle = styled(Typography)({
+  textAlign: "center",
+  marginBottom: 8,
+  fontWeight: 600,
+  color: "var(--app-chart-1)",
+});
+
+const FormDescription = styled(Typography)({
+  textAlign: "center",
+  marginBottom: 32,
+  color: "var(--app-muted-fg)",
+});
+
+const StyledTextField = styled(TextField)({
+  marginBottom: 24,
+  "& .MuiOutlinedInput-root": {
+    "& fieldset": {
+      borderColor: "var(--app-border)",
+    },
+    "&:hover fieldset": {
+      borderColor: "var(--app-chart-1)",
+    },
+    "&.Mui-focused fieldset": {
+      borderColor: "var(--app-chart-1)",
+    },
+  },
+  "& .MuiInputLabel-root.Mui-focused": {
+    color: "var(--app-chart-1)",
+  },
+});
+
+const LoginButton = styled(Button)({
+  padding: "12px 0",
+  marginBottom: 16,
+  backgroundColor: "var(--app-chart-1)",
+  color: "white",
+  fontSize: "1.1rem",
+  fontWeight: 600,
+  borderRadius: 16,
+  textTransform: "none",
+  "&:hover": {
+    backgroundColor: "var(--app-chart-2)",
+    transform: "translateY(-2px)",
+    boxShadow: "0 8px 25px rgba(96, 175, 160, 0.4)",
+  },
+  transition: "all 0.3s ease",
+});
+
+const ForgotPasswordLink = styled(Link)({
+  color: "var(--app-chart-1)",
+  textDecoration: "none",
+  "&:hover": {
+    textDecoration: "underline",
+  },
+});
+
+const DividerText = styled(Typography)({
+  color: "var(--app-muted-fg)",
+  padding: "0 16px",
+});
+
+const RegisterButton = styled(Button)({
+  padding: "12px 0",
+  borderColor: "var(--app-chart-1)",
+  color: "var(--app-chart-1)",
+  fontSize: "1.1rem",
+  fontWeight: 600,
+  borderRadius: 16,
+  textTransform: "none",
+  "&:hover": {
+    borderColor: "var(--app-chart-2)",
+    backgroundColor: "rgba(96, 175, 160, 0.05)",
+    transform: "translateY(-2px)",
+  },
+  transition: "all 0.3s ease",
+});

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+
 const api = axios.create({
-  baseURL: `${import.meta.env.VITE_BACKEND_URL}/api`,
+  baseURL: `${BACKEND_URL}/api`,
   headers: {
     "Content-Type": "application/json",
     authorization: `Bearer ${sessionStorage.getItem("token")}`,


### PR DESCRIPTION
## 개요

로그인 페이지 퍼플리싱 완료했습니다.

## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 로그인 페이지 전체적인 디자인작업 하였습니다.
- 추후 기능 연결이 되면 구글로그인 버튼도 추가될 예정입니다.

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점
- (없다면 패스)

### 어려웠던 점 / 에로사항
- index.css에 정의되어있는 색을 가져다 쓰는게 힘들었음
- 초록계열 색에 대한 정리가 필요할 것 같음

### 다음에 개선하고 싶은 점
- 기능연결, 회원가입페이지 퍼블리싱

### 팀원들과 공유하고 싶은 팁

<img width="35" height="26" alt="image" src="https://github.com/user-attachments/assets/57d826aa-1952-4759-837e-2fcebc80099f" />
--app-chart-1


