### PR TITLE
Feat/ 단어장 내 단어 삭제 및 상태 변경 기능 추가

### DIFF
--- a/src/pages/VocabPage/VocabPage.jsx
+++ b/src/pages/VocabPage/VocabPage.jsx
@@ -1,17 +1,22 @@
 import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import VocabHeader from "./component/VocabHeader";
 import VocabBodyProgress from "./component/VocabBodyProgress";
 import VocabBodySearch from "./component/VocabBodySearch";
 import VocabBodyWord from "./component/VocabBodyWord";
 import "./VocabPage.style.css";
 
-const VocabPage = ({ diaryId }) => {
+const VocabPage = () => {
+  const { diaryId } = useParams();
+  console.log("diaryId:", diaryId);
   const [vocabList, setVocabList] = useState([]);
   const [filteredList, setFilteredList] = useState([]);
   const [filter, setFilter] = useState("All"); // All, Mastered, Learning
+  const [searchQuery, setSearchQuery] = useState(""); //Query
 
   useEffect(() => {
-    fetch(`/api/vocab/${diaryId}`)
+    if (!diaryId) return; // diaryId 없으면 fetch 안함
+    fetch(`${import.meta.env.VITE_BACKEND_URL}/api/vocab/${diaryId}`)
       .then((res) => res.json())
       .then((data) => {
         setVocabList(data);
@@ -21,26 +26,78 @@ const VocabPage = ({ diaryId }) => {
   }, [diaryId]);
 
   useEffect(() => {
-    if (filter === "All") setFilteredList(vocabList);
-    else
-      setFilteredList(
-        vocabList.filter(
-          (vocab) => vocab.status.toLowerCase() === filter.toLowerCase()
-        )
+    //get 할때 가져올 전체리스트
+    console.log("vocabList:", vocabList);
+  }, [vocabList]);
+
+  useEffect(() => {
+    //상태, 검색어 다 저장
+    let filtered = vocabList;
+
+    // 상태 필터링
+    if (filter !== "All") {
+      filtered = filtered.filter(
+        (vocab) => vocab.status.toLowerCase() === filter.toLowerCase()
       );
-  }, [filter, vocabList]);
+    }
+
+    // 검색어 필터링
+    if (searchQuery.trim() !== "") {
+      filtered = filtered.filter((vocab) =>
+        vocab.word.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+    }
+
+    setFilteredList(filtered);
+  }, [filter, searchQuery, vocabList]);
+
+  const handleToggleStatus = async (id) => {
+    try {
+      const res = await fetch(
+        //상대경로에선 막혀서 절대경로 사용
+        `${import.meta.env.VITE_BACKEND_URL}/api/vocab/${id}`,
+        {
+          method: "POST",
+        }
+      );
+      const updated = await res.json(); //응답대기
+
+      setVocabList((prev) =>
+        prev.map((v) => (v._id === id ? { ...v, status: updated.status } : v))
+      );
+    } catch (err) {
+      console.error("Toggle failed:", err);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      await fetch(`${import.meta.env.VITE_BACKEND_URL}/api/vocab/${id}`, {
+        method: "DELETE",
+      });
+
+      setVocabList((prev) => prev.filter((v) => v._id !== id));
+    } catch (err) {
+      console.error("Delete failed:", err);
+    }
+  };
 
   return (
     <div>
-      <VocabHeader
-        diaryId="64f0c2e1ab1234abcd567890"
-        setVocabList={setVocabList}
-      />
+      <VocabHeader diaryId={diaryId} setVocabList={setVocabList} />
       <div className="voca-page voca-color">
-        <VocabBodyProgress vocabList={vocabList} />
-        <VocabBodySearch setFilter={setFilter} />
+        <VocabBodyProgress vocabList={vocabList} setFilter={setFilter} />
+        <VocabBodySearch
+          setFilter={setFilter}
+          setSearchQuery={setSearchQuery}
+        />
         {filteredList.map((vocab) => (
-          <VocabBodyWord key={vocab._id} vocab={vocab} />
+          <VocabBodyWord
+            key={vocab._id}
+            vocab={vocab}
+            onToggleStatus={handleToggleStatus}
+            onDelete={handleDelete}
+          />
         ))}
       </div>
     </div>

--- a/src/pages/VocabPage/VocabPage.jsx
+++ b/src/pages/VocabPage/VocabPage.jsx
@@ -1,21 +1,47 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import VocabHeader from "./component/VocabHeader";
 import VocabBodyProgress from "./component/VocabBodyProgress";
 import VocabBodySearch from "./component/VocabBodySearch";
 import VocabBodyWord from "./component/VocabBodyWord";
 import "./VocabPage.style.css";
 
-const VocabPage = () => {
+const VocabPage = ({ diaryId }) => {
+  const [vocabList, setVocabList] = useState([]);
+  const [filteredList, setFilteredList] = useState([]);
+  const [filter, setFilter] = useState("All"); // All, Mastered, Learning
+
+  useEffect(() => {
+    fetch(`/api/vocab/${diaryId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setVocabList(data);
+        setFilteredList(data);
+      })
+      .catch(console.error);
+  }, [diaryId]);
+
+  useEffect(() => {
+    if (filter === "All") setFilteredList(vocabList);
+    else
+      setFilteredList(
+        vocabList.filter(
+          (vocab) => vocab.status.toLowerCase() === filter.toLowerCase()
+        )
+      );
+  }, [filter, vocabList]);
+
   return (
     <div>
-      <VocabHeader />
+      <VocabHeader
+        diaryId="64f0c2e1ab1234abcd567890"
+        setVocabList={setVocabList}
+      />
       <div className="voca-page voca-color">
-        <VocabBodyProgress />
-        <VocabBodySearch />
-        <VocabBodyWord />
-        <VocabBodyWord />
-        <VocabBodyWord />
-        <VocabBodyWord />
+        <VocabBodyProgress vocabList={vocabList} />
+        <VocabBodySearch setFilter={setFilter} />
+        {filteredList.map((vocab) => (
+          <VocabBodyWord key={vocab._id} vocab={vocab} />
+        ))}
       </div>
     </div>
   );

--- a/src/pages/VocabPage/VocabPage.style.css
+++ b/src/pages/VocabPage/VocabPage.style.css
@@ -177,6 +177,34 @@
   margin: 0.3rem;
 }
 
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); /* 반투명 배경 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  padding: 20px;
+  border-radius: 12px;
+  min-width: 300px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal-buttons {
+  margin-top: 15px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
 @media (max-width: 768px) {
   /* 전체 페이지 패딩 축소 */
   .voca-page {

--- a/src/pages/VocabPage/VocabPage.style.css
+++ b/src/pages/VocabPage/VocabPage.style.css
@@ -81,6 +81,16 @@
   font-weight: 600;
 }
 
+/* Progress 카드에는 호버 제거 */
+.white-card.progress {
+  cursor: default;
+}
+
+.white-card.progress:hover {
+  transform: none;
+  font-weight: 500;
+}
+
 .voca-black-bold {
   margin: 0.3rem;
   display: block;
@@ -121,6 +131,45 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.word-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.word-info {
+  flex: 1;
+  min-width: 250px;
+}
+
+.action-button {
+  outline: none;
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.action-button.toggle {
+  background-color: rgb(255, 255, 255);
+  border: 1px solid rgb(65, 180, 105);
+  color: rgb(65, 180, 105);
+}
+.action-button.toggle:hover {
+  font-weight: 700;
+}
+
+.action-button.delete {
+  background-color: rgb(255, 255, 255);
+  border: 1px solid rgb(222, 85, 70);
+  color: rgb(222, 85, 70);
+}
+.action-button.delete:hover {
+  font-weight: 700;
+}
+
 .search-input-place {
   display: flex;
   background-color: white;
@@ -149,6 +198,7 @@
 
 .word-title-status-date {
   display: flex;
+  align-items: center;
 }
 
 .word-title {
@@ -157,13 +207,17 @@
 }
 
 .word-description {
+  display: flex;
+  align-items: center;
   font-weight: 400;
   margin: 0.3rem;
+  gap: 5px;
 }
 
 .word-example {
   display: flex;
   font-style: italic;
+  margin-bottom: 1rem;
 }
 
 .mastered-box {
@@ -171,6 +225,17 @@
   align-items: center;
   background-color: rgb(92, 220, 77);
   color: rgb(255, 255, 255);
+  padding: 0.2rem 0.3rem;
+  border-radius: 0.4rem;
+  font-weight: 500;
+  margin: 0.3rem;
+}
+
+.learning-box {
+  outline: none;
+  align-items: center;
+  background-color: rgb(255, 228, 211);
+  color: rgb(222, 85, 70);
   padding: 0.2rem 0.3rem;
   border-radius: 0.4rem;
   font-weight: 500;
@@ -282,5 +347,20 @@
   .mastered-box {
     padding: 0.15rem 0.25rem;
     font-size: 0.8rem;
+  }
+
+  .word-actions {
+    flex-direction: row;
+    margin-left: 0;
+    margin-top: 1rem;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 0.6rem;
+  }
+
+  .action-button {
+    flex: 1;
+    font-size: 0.8rem;
+    padding: 0.3rem 0.6rem;
   }
 }

--- a/src/pages/VocabPage/component/VocabBodyProgress.jsx
+++ b/src/pages/VocabPage/component/VocabBodyProgress.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "../VocabPage.style.css";
 
-const VocabBodyProgress = ({ vocabList }) => {
+const VocabBodyProgress = ({ vocabList, setFilter }) => {
   const totalWord = vocabList.length;
   const masteredWord = vocabList.filter((v) => v.status === "mastered").length;
   const learningWord = vocabList.filter((v) => v.status === "learning").length;
@@ -9,18 +9,18 @@ const VocabBodyProgress = ({ vocabList }) => {
 
   return (
     <div className="voca-body-progress">
-      <div className="white-card">
+      <div className="white-card" onClick={() => setFilter("All")}>
         <span className="voca-black-bold">{totalWord}</span>
         Total Words
       </div>
-      <div className="white-card">
+      <div className="white-card" onClick={() => setFilter("mastered")}>
         <span className="voca-green-bold">{masteredWord}</span>
         Mastered
       </div>
-      <div className="white-card">
+      <div className="white-card" onClick={() => setFilter("learning")}>
         <span className="voca-red-bold">{learningWord}</span>Learning
       </div>
-      <div className="white-card">
+      <div className="white-card progress">
         <span className="voca-black-bold">{progress}%</span>Progress
       </div>
     </div>

--- a/src/pages/VocabPage/component/VocabBodyProgress.jsx
+++ b/src/pages/VocabPage/component/VocabBodyProgress.jsx
@@ -1,19 +1,15 @@
 import React from "react";
 import "../VocabPage.style.css";
 
-import { useNavigate } from "react-router-dom";
-
-const VocabBodyProgress = () => {
-  const navigate = useNavigate();
-  //숫자들 하드코딩
-  const totalWord = 4;
-  const masteredWord = 3;
-  const learningWord = 1;
-  const progress = (masteredWord / totalWord) * 100;
+const VocabBodyProgress = ({ vocabList }) => {
+  const totalWord = vocabList.length;
+  const masteredWord = vocabList.filter((v) => v.status === "mastered").length;
+  const learningWord = vocabList.filter((v) => v.status === "learning").length;
+  const progress = totalWord ? Math.round((masteredWord / totalWord) * 100) : 0;
 
   return (
     <div className="voca-body-progress">
-      <div className="white-card" onClick={() => navigate("/")}>
+      <div className="white-card">
         <span className="voca-black-bold">{totalWord}</span>
         Total Words
       </div>

--- a/src/pages/VocabPage/component/VocabBodySearch.jsx
+++ b/src/pages/VocabPage/component/VocabBodySearch.jsx
@@ -1,17 +1,8 @@
 import React from "react";
 import "../VocabPage.style.css";
-
 import SearchIcon from "@mui/icons-material/Search";
 
-const VocabBodySearch = () => {
-  //   const [query, setQuery] = useState("");
-
-  //   const handleKeyDown = (e) => {
-  //     if (e.key === "Enter") {
-  //         onSearch(query);
-  //     }
-  //   };
-
+const VocabBodySearch = ({ setFilter }) => {
   return (
     <div className="white-card-long">
       <div className="search-input-place">
@@ -20,14 +11,19 @@ const VocabBodySearch = () => {
           type="text"
           className="search-input-box"
           placeholder="Search Vocabulary..."
-          // onChange={(e) => setQuery(e.target.value)}
-          // onKeyDown={handleKeyDown}
+          onChange={(e) => setFilter(e.target.value)}
         />
       </div>
       <div className="word-button">
-        <button className="white-button">All</button>
-        <button className="white-button">Masterd</button>
-        <button className="white-button">Learning</button>
+        <button className="white-button" onClick={() => setFilter("All")}>
+          All
+        </button>
+        <button className="white-button" onClick={() => setFilter("mastered")}>
+          Mastered
+        </button>
+        <button className="white-button" onClick={() => setFilter("learning")}>
+          Learning
+        </button>
       </div>
     </div>
   );

--- a/src/pages/VocabPage/component/VocabBodySearch.jsx
+++ b/src/pages/VocabPage/component/VocabBodySearch.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import "../VocabPage.style.css";
 import SearchIcon from "@mui/icons-material/Search";
 
-const VocabBodySearch = ({ setFilter }) => {
+const VocabBodySearch = ({ setFilter, setSearchQuery }) => {
   return (
     <div className="white-card-long">
       <div className="search-input-place">
@@ -11,7 +11,7 @@ const VocabBodySearch = ({ setFilter }) => {
           type="text"
           className="search-input-box"
           placeholder="Search Vocabulary..."
-          onChange={(e) => setFilter(e.target.value)}
+          onChange={(e) => setSearchQuery(e.target.value)}
         />
       </div>
       <div className="word-button">

--- a/src/pages/VocabPage/component/VocabBodyWord.jsx
+++ b/src/pages/VocabPage/component/VocabBodyWord.jsx
@@ -1,28 +1,52 @@
 import React from "react";
 import "../VocabPage.style.css";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 
-const VocabBodyWord = () => {
-  //하드코딩
+const VocabBodyWord = ({ vocab, onToggleStatus, onDelete }) => {
   return (
     <div className="white-card-long">
-      <div className="word-title-status-date">
-        <div className="word-title">green</div>
-        <div className="mastered-box">Mastered</div>
-        <div className="word-description">
-          <i class="fa-regular fa-calendar"></i> 2025.04.02
+      {/* 단어 정보 */}
+      <div className="word-info">
+        <div className="word-title-status-date">
+          <div className="word-title">{vocab.word}</div>
+          <div
+            className={
+              vocab.status === "mastered" ? "mastered-box" : "learning-box"
+            }
+          >
+            {vocab.status}
+          </div>
+
+          <div className="word-description">
+            <CalendarMonthIcon sx={{ fontSize: 20 }} />{" "}
+            {new Date(vocab.createdAt).toLocaleDateString()}
+          </div>
+        </div>
+
+        <div className="word-title-status-date">
+          <span className="word-title">definistion:</span>
+          <span className="word-description">{vocab.meaning}</span>
+        </div>
+        <div className="word-example">
+          <span className="word-title">Example:</span>
+          <span className="word-description">{vocab.example}</span>
         </div>
       </div>
-      <div className="word-title-status-date">
-        <span className="word-title">definistion:</span>
-        <span className="word-description">
-          having the colour of grass or the leaves of most plants and trees
-        </span>
-      </div>
-      <div className="word-example">
-        <span className="word-title">Example:</span>
-        <span className="word-description">
-          Wait for the light to turn green (= on traffic lights).
-        </span>
+
+      {/* 버튼 정보 */}
+      <div className="word-actions">
+        <button
+          className="action-button toggle"
+          onClick={() => onToggleStatus(vocab._id)}
+        >
+          {vocab.status === "mastered" ? "Set Learning" : "Set Mastered"}
+        </button>
+        <button
+          className="action-button delete"
+          onClick={() => onDelete(vocab._id)}
+        >
+          Delete
+        </button>
       </div>
     </div>
   );

--- a/src/pages/VocabPage/component/VocabHeader.jsx
+++ b/src/pages/VocabPage/component/VocabHeader.jsx
@@ -1,20 +1,60 @@
-import React from "react";
-// import { useNavigate } from "react-router-dom";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import TrackChangesIcon from "@mui/icons-material/TrackChanges";
 import WestIcon from "@mui/icons-material/West";
 import "../VocabPage.style.css";
 
 const VocabHeader = () => {
+  const navigate = useNavigate();
+  const handleBackToDairy = () => {
+    navigate("/diary");
+  };
+
+  const [showForm, setShowForm] = useState(false);
+
+  const handleOpenForm = () => {
+    setShowForm(true);
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+  };
+
   return (
     <div className="voca-header">
-      <button className="white-button">
+      <button className="white-button" onClick={handleBackToDairy}>
         <WestIcon sx={{ fontSize: 15 }} /> Back
       </button>
       <TrackChangesIcon className="voca-header-title" sx={{ fontSize: 30 }} />
       <div className="voca-header-title">My Vocabulary</div>
-      <button className="white-button voca-header-add-button">
+      <button
+        className="white-button voca-header-add-button"
+        onClick={handleOpenForm}
+      >
         + Add Word
       </button>
+
+      {/* Add button 해서 단어를 추가하는 게 맞는지? */}
+      {showForm && (
+        <div className="modal-overlay" onClick={handleCloseForm}>
+          <div
+            className="modal-content"
+            onClick={(e) => e.stopPropagation()} // 배경 클릭 시 닫힘 방지
+          >
+            <h2>Add a new word</h2>
+            <form className="add-word-form">
+              <input type="text" placeholder="Enter new word" />
+              <input type="text" placeholder="Meaning" />
+              <div className="modal-buttons">
+                <button type="submit">Save</button>
+                <button type="button" onClick={handleCloseForm}>
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -14,6 +14,7 @@ const AppRouter = () => {
       <Route path="/register" element={<Register />} />
       <Route element={<PrivateRoute />}></Route>
       <Route path="/vocab" element={<Vocab />} />
+      <Route path="/vocab/:diaryId" element={<Vocab />} />
       <Route path="/daily" element={<Daily />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>


### PR DESCRIPTION
## 개요

단어장 내 단어 삭제 및 상태 변경 기능 추가하였습니다.

## 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- VocaWord에서 단어 상태 수정과 삭제 버튼을 추가하였습니다
- delete버튼을 누르면 db내 isDeleted가 true로 바뀌고 프론트에서 필터링을 통해 삭제된 것처럼 보이게 구현하였습니다
- set Mastered/ set Learning 버튼을 통해 상태를 토글할 수 있게 하였습니다

## 개발 후기 및 개선사항

- VocaProgress, VocaSearch, VocaWord 의 하드코딩된 부분들을 백엔드와 연결하였습니다

### 이번 작업에서 배운 점

`  `${import.meta.env.VITE_BACKEND_URL}/api/vocab/${id}` `
- fetch 할 때 상대경로를 했을 때 연결되지 않았는데 절대경로를 하니 바로 연결되었습니다

### 어려웠던 점 / 에로사항

 ` const [filter, setFilter] = useState("All"); // All, Mastered, Learning`
- 단어 상태에 대해 어떻게 구현할지 복잡하게 생각했는데 상태에는 없지만 두 상태 모두를 나타내는 상태인 all을 이용하니 mastered, learning을 동시에 다룰 수 있어 편리했습니다.

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
