### PR TITLE
Feat/diary: 일기 작성 가능 날짜 제한 로직 구현 및 일기 작성 버튼 생성

### DIFF
--- a/src/pages/DailyPage/components/DiaryBox.jsx
+++ b/src/pages/DailyPage/components/DiaryBox.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import NewDiaryDialog from "./NewDiaryDialog";
-import { Card, CardContent, Typography, Box } from "@mui/material";
+import { Card, CardContent, Typography, Box, Button } from "@mui/material";
 import useDiaryStore from "../../../stores/useDiaryStore";
+import dayjs from "dayjs";
 
 const DiaryBox = () => {
   const { selectedDate, setSelectedDate, diaries } = useDiaryStore();
@@ -20,6 +21,13 @@ const DiaryBox = () => {
 
   const dateKey = selectedDate.format("YYYY-MM-DD");
   const diary = diaries[dateKey];
+
+  const today = dayjs().startOf("day");
+  const target = selectedDate.startOf("day");
+  const dayDiff = today.diff(target, "day"); // 0,1,2면 OK / 음수면 미래 / 3이상이면 오래전
+  const isWritableDay = dayDiff >= 0 && dayDiff <= 2;
+
+  const canCreate = !diary && isWritableDay;
 
   return (
     <>
@@ -48,6 +56,11 @@ const DiaryBox = () => {
           <Typography variant="body1" color="text.secondary">
             {diary ? diary.content : "No Diary for this date yet."}
           </Typography>
+          {canCreate && (
+            <Button onClick={() => setOpenDialog(true)} variant="contained">
+              일기 작성하기
+            </Button>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## 개요

일기 작성 가능 날짜 제한 로직 구현 및 일기 작성 버튼 생성

## 변경 사항

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  리팩토링
- [ ]  문서 수정

## 구현 내용

- dayjs diff를 활용해 오늘/어제/그제(0~2일 차)만 작성 가능하도록 제한
- 선택한 날짜에 일기가 없고 작성 가능 범위일 때만 '일기 작성하기' 버튼 노출
- 미래 날짜 및 3일 이상 지난 날짜는 작성 버튼 숨김 처리

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
