### PR TITLE
Feat/diary: API 연동으로 랜딩 페이지와 마이페이지에 일기 데이터를 표시

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -330,229 +330,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@csstools/cascade-layer-name-parser": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.5.tgz",
-      "integrity": "sha512-p1ko5eHgV+MgXFVa4STPKpvPxr6ReS8oS2jzTukjR74i5zJNyWO1ZM1m8YKBXnzDKWfBN1ztLYlHxbVemDD88A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
-      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/selector-resolve-nested": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
-      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/utilities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-2.0.0.tgz",
-      "integrity": "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -2262,36 +2039,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/axios": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -2531,99 +2278,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-blank-pseudo": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-7.0.1.tgz",
-      "integrity": "sha512-jf+twWGDf6LDoXDUode+nc7ZlrqfaNphrBIBrcmeP3D8yw1uPaix1gCC8LUQUGQ6CycuK2opkbFFWFuq/a94ag==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/css-has-pseudo": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.2.tgz",
-      "integrity": "sha512-nzol/h+E0bId46Kn2dQH5VElaknX2Sr0hFuB/1EomdC7j+OISt2ZzK7EHX9DZDY53WbIVAR7FYKSO2XnSf07MQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "dependencies": {
-        "@csstools/selector-specificity": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/css-prefers-color-scheme": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-10.0.0.tgz",
-      "integrity": "sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/cssdb": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.0.tgz",
-      "integrity": "sha512-lyATYGyvXwQ8h55WeQeEHXhI+47rl52pXSYkFK/ZrCbAJSgVIaPFjYc3RM8TpRHKk7W3wsAZImmLps+P5VyN9g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        }
-      ],
-      "license": "MIT-0"
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -3140,20 +2794,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3609,25 +3249,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3641,16 +3262,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4058,16 +3669,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4191,13 +3792,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.2",

--- a/src/apis/diaryApi.js
+++ b/src/apis/diaryApi.js
@@ -1,0 +1,36 @@
+import api from "../util/api";
+
+export const readAllDiaries = async ({ lastId }) => {
+  const path = "/diary";
+  try {
+    const response = await api.get(path, {
+      params: { lastId: lastId ?? undefined },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("readAllDiaries API 에러:", error);
+    throw error;
+  }
+};
+
+export const readUserDiariesByMonth = async ({ year, month }) => {
+  const path = "/diary/my/month";
+  try {
+    const response = await api.get(path, { params: { year, month } });
+    return response.data;
+  } catch (error) {
+    console.error("readUserDiariesByMonth API 에러:", error);
+    throw error;
+  }
+};
+
+export const readUserDiaryByDate = async ({ date }) => {
+  const path = "/diary/my/date";
+  try {
+    const response = await api.get(path, { params: { date } });
+    return response.data;
+  } catch (error) {
+    console.error("readUserDiaryByDate API 에러:", error);
+    throw error;
+  }
+};

--- a/src/hooks/useReadAllDiaries.js
+++ b/src/hooks/useReadAllDiaries.js
@@ -1,0 +1,16 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { readAllDiaries } from "../apis/diaryApi";
+
+const useReadAllDiaries = () => {
+  return useInfiniteQuery({
+    queryKey: ["allDiaries"],
+    queryFn: ({ pageParam }) => readAllDiaries({ lastId: pageParam ?? null }),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => lastPage?.nextLastId ?? null,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+  });
+};
+
+export default useReadAllDiaries;

--- a/src/hooks/useReadDailyDiary.js
+++ b/src/hooks/useReadDailyDiary.js
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { readUserDiaryByDate } from "../apis/diaryApi";
+import useDiaryStore from "../stores/useDiaryStore";
+import { useEffect } from "react";
+
+const useReadDailyDiary = ({ date }) => {
+  const { setDiaryForDate } = useDiaryStore();
+
+  const query = useQuery({
+    queryKey: ["myDailyDiary", date],
+    queryFn: () => readUserDiaryByDate({ date }),
+    enabled: !!date,
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    if (query.data) setDiaryForDate(date, query.data.diary ?? null);
+  }, [query.data, date, setDiaryForDate]);
+
+  return query;
+};
+
+export default useReadDailyDiary;

--- a/src/hooks/useReadMonthlyDiaries.js
+++ b/src/hooks/useReadMonthlyDiaries.js
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { readUserDiariesByMonth } from "../apis/diaryApi";
+import useDiaryStore from "../stores/useDiaryStore";
+import { useEffect } from "react";
+
+const useReadMonthlyDiaries = ({ year, month }) => {
+  const { setMonthDays } = useDiaryStore();
+
+  const query = useQuery({
+    queryKey: ["myMonthlyDiaries", year, month],
+    queryFn: () => readUserDiariesByMonth({ year, month }),
+    enabled: Number.isInteger(year) && Number.isInteger(month),
+    staleTime: 1000 * 60, // 1분 캐싱
+    placeholderData: (prev) => prev,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    if (query.data?.days) {
+      setMonthDays(query.data.days);
+    } else if (query.isError) {
+      console.error("month query error:", query.error);
+    }
+  }, [query.data, query.isError, query.error, setMonthDays]);
+
+  return query;
+};
+
+export default useReadMonthlyDiaries;

--- a/src/pages/DailyPage/components/Calendar.jsx
+++ b/src/pages/DailyPage/components/Calendar.jsx
@@ -2,12 +2,17 @@ import React, { useState } from "react";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DateCalendar } from "@mui/x-date-pickers/DateCalendar";
+import { PickersDay } from "@mui/x-date-pickers/PickersDay";
+import Badge from "@mui/material/Badge";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { styled } from "@mui/material/styles";
 import useDiaryStore from "../../../stores/useDiaryStore";
+import useReadMonthlyDiaries from "../../../hooks/useReadMonthlyDiaries";
 
-// styled에서 props로 isDesktop 받기
-const StyledDateCalendar = styled(DateCalendar)(({ isDesktop }) => ({
+// styled에서 props로 isDesktop 받기 (DOM으로 전달되지 않도록 필터)
+const StyledDateCalendar = styled(DateCalendar, {
+  shouldForwardProp: (prop) => prop !== "isDesktop",
+})(({ isDesktop }) => ({
   margin: "10px",
   height: isDesktop ? "500px" : "auto",
   width: isDesktop ? "600px" : "100%",
@@ -17,40 +22,55 @@ const StyledDateCalendar = styled(DateCalendar)(({ isDesktop }) => ({
     fontWeight: 600,
     marginBottom: "6px",
   },
-  "& div[role='row']": {
-    justifyContent: "space-around",
-  },
-  "& .MuiDayCalendar-slideTransition": {
-    minHeight: isDesktop ? 500 : 350,
-  },
+  "& div[role='row']": { justifyContent: "space-around" },
+  "& .MuiDayCalendar-slideTransition": { minHeight: isDesktop ? 500 : 350 },
   "& .MuiPickersDay-root": {
     height: isDesktop ? 70 : 40,
     width: isDesktop ? 70 : 40,
     fontSize: isDesktop ? "1.2rem" : "0.9rem",
     margin: isDesktop ? 4 : 2,
   },
-  "& .MuiMonthCalendar-root": {
-    // 월 선택 달력 전체
-    width: isDesktop ? 500 : 320, // 모바일은 화면 맞춤
-    height: isDesktop ? 200 : "100%",
-    gap: isDesktop ? 9 : 9, // 월 버튼 간격
-    padding: isDesktop ? "10px" : "4px",
-  },
-  "& .MuiPickersMonth-root": {
-    // 개별 월 버튼
-    width: isDesktop ? 60 : 40,
-    height: isDesktop ? 60 : 32,
-    fontSize: isDesktop ? "1rem" : "0.8rem",
-    margin: isDesktop ? 4 : 2,
-  },
 }));
 
-const Calendar = () => {
-  const { selectedDate, setSelectedDate, diaries } = useDiaryStore();
-  const [currentView, setCurrentView] = useState("day");
-
-  // ✅ 여기서만 선언
+function DayWithDot(props) {
+  const { day, outsideCurrentMonth } = props;
   const isDesktop = useMediaQuery("(min-width:768px)");
+  const { daysMap } = useDiaryStore.getState(); // 최신 스토어 값
+  const dk = day.format("YYYY-MM-DD");
+  const hasEntry = !!daysMap[dk]?.id;
+
+  if (outsideCurrentMonth) return <PickersDay {...props} />;
+
+  const DOT = isDesktop ? 10 : 8;
+  const TOP = isDesktop ? 26 : 10;
+  const RIGHT = isDesktop ? 20 : 12;
+
+  return (
+    <Badge
+      overlap="circular"
+      variant={hasEntry ? "dot" : undefined}
+      color="error"
+      anchorOrigin={{ vertical: "top", horizontal: "right" }}
+      sx={{
+        "& .MuiBadge-badge": { zIndex: 2 },
+        "& .MuiBadge-dot": { width: DOT, height: DOT, borderRadius: "50%" },
+        "& .MuiBadge-anchorOriginTopRightCircular": { top: TOP, right: RIGHT },
+      }}
+    >
+      <PickersDay {...props} />
+    </Badge>
+  );
+}
+
+export default function Calendar() {
+  const { selectedDate, setSelectedDate } = useDiaryStore();
+  const [currentView, setCurrentView] = useState("day");
+  const isDesktop = useMediaQuery("(min-width:768px)");
+
+  const year = selectedDate.year();
+  const month = selectedDate.month() + 1;
+
+  useReadMonthlyDiaries({ year, month });
 
   return (
     <>
@@ -59,33 +79,26 @@ const Calendar = () => {
           isDesktop={isDesktop}
           value={selectedDate}
           view={currentView}
-          onViewChange={(newView) => setCurrentView(newView)}
-          onChange={(newDate) => setSelectedDate(newDate)}
+          onViewChange={(v) => setCurrentView(v)}
+          onChange={(d) => setSelectedDate(d)}
           views={["year", "month", "day"]}
+          slots={{ day: DayWithDot }} // 커스텀 데이 적용
           slotProps={{
             day: {
               sx: {
-                "&.Mui-selected": {
-                  backgroundColor: "#4caf50",
-                  color: "#fff",
-                },
-                "&.Mui-selected:hover": {
-                  backgroundColor: "#388e3c",
-                },
+                "&.Mui-selected": { backgroundColor: "#4caf50", color: "#fff" },
+                "&.Mui-selected:hover": { backgroundColor: "#388e3c" },
                 "&.Mui-selected:focus, &.Mui-selected.Mui-focusVisible": {
                   backgroundColor: "#388e3c",
                   outline: "none",
                 },
-                "&.MuiPickersDay-today": {
-                  border: "2px solid #4caf50",
-                },
+                "&.MuiPickersDay-today": { border: "2px solid #4caf50" },
               },
             },
           }}
         />
       </LocalizationProvider>
 
-      {/* Today / Has Entry 표시 */}
       <div
         style={{
           display: "flex",
@@ -124,6 +137,4 @@ const Calendar = () => {
       </div>
     </>
   );
-};
-
-export default Calendar;
+}

--- a/src/pages/DailyPage/components/DiaryBox.jsx
+++ b/src/pages/DailyPage/components/DiaryBox.jsx
@@ -1,12 +1,22 @@
-import React, { useState } from "react";
+import { useMemo, useState } from "react";
 import NewDiaryDialog from "./NewDiaryDialog";
-import { Card, CardContent, Typography, Box, Button } from "@mui/material";
+import { Card, CardContent, Typography, Button, styled } from "@mui/material";
 import useDiaryStore from "../../../stores/useDiaryStore";
 import dayjs from "dayjs";
+import useReadDailyDiary from "../../../hooks/useReadDailyDiary";
 
 const DiaryBox = () => {
-  const { selectedDate, setSelectedDate, diaries } = useDiaryStore();
+  const { selectedDate, diariesByDate } = useDiaryStore();
   const [openDialog, setOpenDialog] = useState(false);
+
+  const dateKey = useMemo(
+    () => selectedDate.format("YYYY-MM-DD"),
+    [selectedDate]
+  );
+
+  const { isFetching: isFetchingDiary } = useReadDailyDiary({ date: dateKey });
+
+  const diary = diariesByDate[dateKey] || null;
 
   const formatDate = (date) => {
     return new Intl.DateTimeFormat("en-US", {
@@ -17,16 +27,10 @@ const DiaryBox = () => {
     }).format(date.toDate());
   };
 
-  const handleCloseDialog = () => setOpenDialog(false);
-
-  const dateKey = selectedDate.format("YYYY-MM-DD");
-  const diary = diaries[dateKey];
-
   const today = dayjs().startOf("day");
   const target = selectedDate.startOf("day");
-  const dayDiff = today.diff(target, "day"); // 0,1,2면 OK / 음수면 미래 / 3이상이면 오래전
+  const dayDiff = today.diff(target, "day"); // 0~2만 작성 가능
   const isWritableDay = dayDiff >= 0 && dayDiff <= 2;
-
   const canCreate = !diary && isWritableDay;
 
   return (
@@ -50,12 +54,23 @@ const DiaryBox = () => {
             flexGrow: 1,
           }}
         >
-          <Typography variant="h5" gutterBottom>
-            Diary for {formatDate(selectedDate)}
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            {diary ? diary.content : "No Diary for this date yet."}
-          </Typography>
+          <DiaryDate>Diary for {formatDate(selectedDate)}</DiaryDate>
+
+          {isFetchingDiary ? (
+            <Typography variant="body1" color="text.secondary">
+              Loading...
+            </Typography>
+          ) : diary ? (
+            <>
+              <DiaryTitle>{diary.title}</DiaryTitle>
+              <DiaryContent variant="body1">{diary.content}</DiaryContent>
+            </>
+          ) : (
+            <Typography variant="body1" color="text.secondary">
+              No Diary for this date yet.
+            </Typography>
+          )}
+
           {canCreate && (
             <Button onClick={() => setOpenDialog(true)} variant="contained">
               일기 작성하기
@@ -66,7 +81,7 @@ const DiaryBox = () => {
 
       <NewDiaryDialog
         open={openDialog}
-        onClose={handleCloseDialog}
+        onClose={() => setOpenDialog(false)}
         selectedDate={selectedDate}
       />
     </>
@@ -74,3 +89,21 @@ const DiaryBox = () => {
 };
 
 export default DiaryBox;
+
+const DiaryDate = styled(Typography)(({ theme }) => ({
+  color: theme.palette.success.light,
+  fontWeight: 700,
+  fontSize: "25px",
+}));
+
+const DiaryTitle = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(1),
+  marginBottom: theme.spacing(1),
+  fontSize: "25px",
+}));
+
+const DiaryContent = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  lineHeight: 1.6,
+  whiteSpace: "pre-line", // 줄바꿈 유지
+}));

--- a/src/pages/LandingPage/LandingPage.style.css
+++ b/src/pages/LandingPage/LandingPage.style.css
@@ -5,7 +5,9 @@
   color: var(--mui-palette-text-primary);
 }
 
-/* ========== HERO ========== */
+/* =========================
+   HERO
+========================= */
 .hero {
   position: relative;
   padding: 96px 0;
@@ -20,7 +22,6 @@
     padding: 64px 0;
   }
 }
-
 .hero-inner {
   text-align: center;
   max-width: 960px;
@@ -68,7 +69,6 @@
 .hero-title-accent {
   color: var(--mui-palette-primary-main);
 }
-
 .hero-desc {
   color: var(--mui-palette-text-secondary);
   max-width: 720px;
@@ -76,7 +76,6 @@
   line-height: 1.6;
   font-size: clamp(14px, 1.8vw, 18px);
 }
-
 .hero-cta {
   display: flex;
   gap: 12px;
@@ -86,6 +85,7 @@
   flex-wrap: wrap;
 }
 
+/* 버튼 */
 .btn-primary {
   background: var(--mui-palette-primary-main) !important;
   color: var(--mui-palette-primary-contrastText) !important;
@@ -114,7 +114,6 @@
   );
   color: var(--mui-palette-primary-main);
 }
-
 .btn-accent {
   background: var(--app-accent) !important;
   color: var(--app-accent-contrast) !important;
@@ -158,7 +157,9 @@
   }
 }
 
-/* ========== WHY SECTION ========== */
+/* =========================
+   WHY SECTION (STATIC CARDS)
+========================= */
 .why {
   padding: 72px 0;
   background: color-mix(
@@ -178,20 +179,21 @@
   margin-top: -20px;
 }
 
-/* 공통 카드 */
 .cards-container {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
   gap: 24px;
 }
+
+/* 공통 .card */
 .card {
   border: 1px solid var(--app-border);
   border-radius: 6px;
-  display: flex;
-  flex-direction: column;
   width: 350px;
   padding: 20px 0 10px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   text-align: center;
   box-shadow: none;
@@ -201,7 +203,6 @@
   box-shadow: 0 8px 20px color-mix(in oklab, var(--app-ring) 40%, transparent);
 }
 .why-card {
-  /* background-color: #f4fff3; */
   background: linear-gradient(to bottom right, #f4fff3, #ffffff);
 }
 
@@ -220,14 +221,16 @@
   font-size: 22px;
   font-weight: 700;
   font-family: var(--app-font-heading);
-  margin-top: 0px;
+  margin-top: 0;
 }
 .card-text {
   color: var(--mui-palette-text-secondary);
   line-height: 1.7;
 }
 
-/* ========== FEED ========== */
+/* =========================
+   FEED SECTION (DIARY CARDS)
+========================= */
 .feed {
   padding: 72px 0;
 }
@@ -235,49 +238,84 @@
   transform: translateY(-4px);
 }
 
-.entry-meta {
+.feed-card {
+  position: relative;
+  height: 330px; /* 카드 고정 높이 */
+  padding-top: 16px; /* 상단 여백(제목만 있을 때) */
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 6px;
+  flex-direction: column;
+  box-sizing: border-box;
 }
-.entry-date {
+
+/* MUI CardHeader 높이 고정(제목 길이와 무관하게 동일) */
+.feed-card .MuiCardHeader-root {
+  padding: 0 20px; /* 좌우 패딩만 */
+  min-height: 72px; /* 제목 영역 고정 */
+  box-sizing: border-box;
+}
+.feed-card .entry-head .entry-title {
+  margin-top: 4px;
+}
+
+/* 본문/메타/Divider/버튼: 항상 같은 위치 */
+.feed-card .card-body {
+  flex: 1; /* 헤더 제외 남은 높이 */
+  display: grid;
+  grid-template-rows: 1fr auto auto auto; /* 본문, meta-bottom, Divider, 버튼 */
+  gap: 12px;
+  padding: 0 20px 12px;
+  box-sizing: border-box;
+}
+
+/* 본문 */
+.feed-card .entry-content {
+  margin: 0;
+  color: var(--mui-palette-text-secondary);
+  line-height: 1.7;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+/* 날짜+작성자: Divider 바로 위에, 우측 정렬 */
+.feed-card .entry-meta-bottom {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
   font-size: 13px;
   color: var(--mui-palette-text-secondary);
 }
-.entry-vocab {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  font-size: 12px;
-  color: var(--app-accent);
+.feed-card .entry-meta-bottom .sep {
+  opacity: 0.6;
+}
+.feed-card .entry-meta-bottom .author {
+  max-width: 140px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
+/* Divider/버튼은 아래에 고정 배치됨 */
+.feed-card .entry-divider {
+  width: 100%;
+  margin: 0;
+}
+.feed-card .btn-outline {
+  width: 100%;
+}
+
+/* 공통 타이포 */
 .entry-title {
   font-size: 20px;
   font-weight: 700;
   font-family: var(--app-font-heading);
 }
-.entry-content {
-  color: var(--mui-palette-text-secondary);
-  line-height: 1.7;
-  margin-top: -15px;
-}
 
-/* 줄임 처리 유틸 */
-.line-clamp-1,
-.line-clamp-3 {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-.line-clamp-1 {
-  -webkit-line-clamp: 1;
-}
-.line-clamp-3 {
-  -webkit-line-clamp: 3;
-}
-
+/* =========================
+   FEED CTA
+========================= */
 .feed-cta {
   display: flex;
   gap: 12px;
@@ -286,7 +324,9 @@
   margin-top: 20px;
 }
 
-/* ========== CTA ========== */
+/* =========================
+   CTA SECTION
+========================= */
 .cta {
   padding: 72px 0;
   background: linear-gradient(
@@ -296,7 +336,7 @@
   );
 }
 
-/* ========== FLOATING BUTTON ========== */
+/* 플로팅 버튼 */
 .floating-write-btn {
   position: fixed;
   left: 50%;

--- a/src/stores/useDiaryStore.js
+++ b/src/stores/useDiaryStore.js
@@ -4,11 +4,25 @@ import dayjs from "dayjs";
 const useDiaryStore = create((set) => ({
   selectedDate: dayjs(),
   diaries: [],
+  daysMap: {}, // { "YYYY-MM-DD": { id, canWrite } }
+  diariesByDate: {}, // { "YYYY-MM-DD": diaryDoc }
 
   setSelectedDate: (date) => set({ selectedDate: date }),
   addDiary: (date, title, content, image, isPublic) =>
     set((state) => ({
       diaries: [...state.diaries, { date, title, content, image, isPublic }],
+    })),
+  setMonthDays: (days) =>
+    set(() => {
+      const map = {};
+      for (const d of days) {
+        map[d.date] = { id: d.id, canWrite: d.canWrite };
+      }
+      return { daysMap: map };
+    }),
+  setDiaryForDate: (dateKey, diary) =>
+    set((state) => ({
+      diariesByDate: { ...state.diariesByDate, [dateKey]: diary },
     })),
 }));
 


### PR DESCRIPTION
## 개요

API 연동으로 랜딩 페이지와 마이페이지에 일기 데이터를 표시하도록 개선

## 변경 사항

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  리팩토링
- [ ]  문서 수정

## 구현 내용

- **`diaryApi.js` : diary API 함수 추가**
    - `readAllDiaries` : 전체 공개 일기 조회 API
    - `readUserDiariesByMonth` : 사용자 월별 일기 조회 API
    - `readUserDiaryByDate` : 특정 날짜 일기 조회 API
    - 에러 로그 출력 및 예외 처리 추가
- **`useReadAllDiaries.js` : `useReadAllDiaries` 훅 구현 (무한 스크롤 조회)**
    - react-query의 `useInfiniteQuery` 기반
    - `readAllDiaries` API 연동
    - `lastId` 커서 기반으로 페이지네이션 처리
    - staleTime, gcTime, retry 등 캐시 전략 설정
- **`useReadDailyDiary.js` : `useReadDailyDiary` 훅 구현 (특정 날짜 일기 조회)**
    - react-query의 `useQuery` 기반
    - `readUserDiaryByDate` API 연동
    - Zustand store와 연계하여 날짜별 일기 상태(`setDiaryForDate`) 업데이트
    - staleTime 설정으로 캐시 관리
- **`useReadMonthlyDiaries.js` : `useReadMonthlyDiaries` 훅 구현 (월 단위 일기 조회)**
    - react-query의 `useQuery` 기반
    - `readUserDiariesByMonth` API 연동
    - Zustand store와 연계해 월별 일기 days 상태 관리
    - staleTime, placeholderData, retry 등 캐시 및 에러 처리 로직 추가
- **`useDiaryStore.js` : `useDiaryStore` 확장 (월별/일별 일기 상태 관리)**
    - `daysMap` 추가 : 날짜별 일기 작성 가능 여부(`id`, `canWrite`) 관리
    - `diariesByDate` 추가 : 날짜별 일기 문서 저장
    - `setMonthDays` 함수 구현 : 월 단위 일기 days → daysMap으로 변환
    - `setDiaryForDate` 함수 구현 : 특정 날짜의 일기를 `diariesByDate`에 저장
- **`Calendar.js` : Calendar 컴포넌트 리팩터링 및 월별 일기 표시 기능 추가**
    - `useReadMonthlyDiaries` 훅 연동하여 월 단위 일기 데이터 불러오기
    - daysMap 기반 커스텀 DayWithDot 컴포넌트 구현 : 일기 존재 시 dot 표시
    - styled(DateCalendar) 개선 : shouldForwardProp 적용으로 DOM 경고 제거
    - slotProps/slots 활용해 날짜 셀 스타일 및 커스텀 데이 적용
    - 전체 구조 정리 및 불필요한 코드 제거
- **`DiaryBox.jsx` : DiaryBox 컴포넌트 리팩터링 및 일기 조회 로직 개선**
    - `useReadDailyDiary` 훅 연동하여 선택 날짜 일기 불러오기
    - diaries 배열 → diariesByDate 맵 구조 적용
    - `useMemo`로 dateKey 최적화, 로딩 상태 표시(`isFetchingDiary`) 추가
    - UI 개선: DiaryDate/DiaryTitle/DiaryContent 컴포넌트 분리
    - 로딩/빈 상태/작성된 일기 조건부 렌더링 처리
    - 불필요한 state 및 핸들러 정리
- **`LandingPage.jsx` : LandingPage 서버 연동 및 UI 개선**
    - localStorage 기반 sampleEntries 제거 → `useReadAllDiaries` 훅 사용
    - Auth 상태 연동 : 비로그인 상태일 때만 “Aiary 시작하기” 버튼 표시
    - 로딩/에러 상태 처리 추가
    - 일기 카드 UI 개선: 제목, 내용, 작성자, 날짜를 명확히 구분

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- 랜딩 페이지에서 “전체 읽기” 버튼 또는 “일기 더보기” 버튼을 누르면,
    - 비로그인 상태일 때 → 로그인 페이지로 리다이렉트
    - 로그인 상태일 때 → 전체 일기 렌더링 & 더 많은 일기 호출
- 마이페이지(일기 페이지) 퍼블리싱

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)