### PR TITLE
Feat/일기에서 단어 추출 후 단어장 저장 기능 구현

### DIFF
--- a/src/apis/vocabApi.js
+++ b/src/apis/vocabApi.js
@@ -1,6 +1,14 @@
 import api from "../util/api";
 
-console.log("Token sent:", sessionStorage.getItem("token"));
+export const createVocab = async (vocab) => {
+  try {
+    const response = await api.post("/vocab", { vocab });
+    return response.data.vocab;
+  } catch (error) {
+    console.error("단어 불러오기 실패:", error);
+    throw error;
+  }
+};
 
 //로그인 후 vocab 리스트 가져오기
 export const getVocabList = async () => {

--- a/src/hooks/useCreateVocab.js
+++ b/src/hooks/useCreateVocab.js
@@ -1,0 +1,47 @@
+// hooks/useCreateVocab.js
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createVocab } from "../apis/vocabApi";
+
+const useCreateVocab = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (vocab) => createVocab(vocab),
+    onSuccess: (data) => {
+      alert(`단어 저장 완료: ${data.word}\n뜻: ${data.meaning}`);
+      queryClient.invalidateQueries(["myVocab"]); // 필요시 단어장 캐시 갱신
+    },
+    onError: (error) => {
+      alert(`저장 실패: ${error.message}`);
+    },
+  });
+
+  // 선택된 단어 처리 함수
+  const handleSelection = (diary) => {
+    if (!diary) return;
+
+    const selected = window.getSelection().toString().trim();
+    console.log("selected: ", selected);
+    if (!selected) return;
+
+    mutation.mutate(selected);
+  };
+
+  // 모바일 롱프레스 처리용
+  let pressTimer;
+
+  const handleTouchStart = (diary) => {
+    if (!diary) return;
+    pressTimer = setTimeout(() => handleSelection(diary), 200);
+  };
+  const handleTouchEnd = () => clearTimeout(pressTimer);
+
+  return {
+    handleSelection,
+    handleTouchStart,
+    handleTouchEnd,
+    isLoading: mutation.isLoading,
+  };
+};
+
+export default useCreateVocab;

--- a/src/pages/DailyPage/components/DiaryBox.jsx
+++ b/src/pages/DailyPage/components/DiaryBox.jsx
@@ -108,6 +108,7 @@ const DiaryBox = () => {
               일기 작성하기
             </Button>
           )}
+
           {canEdit && (
             <Button onClick={openEditForm} variant="contained">
               일기 수정하기

--- a/src/pages/DailyPage/components/DiaryBox.jsx
+++ b/src/pages/DailyPage/components/DiaryBox.jsx
@@ -4,11 +4,14 @@ import { Card, CardContent, Typography, Button, styled } from "@mui/material";
 import useDiaryStore from "../../../stores/useDiaryStore";
 import dayjs from "dayjs";
 import useReadDailyDiary from "../../../hooks/useReadDailyDiary";
+import useCreateVocab from "../../../hooks/useCreateVocab";
 
 const DiaryBox = () => {
   const { selectedDate, diariesByDate } = useDiaryStore();
   const [openDialog, setOpenDialog] = useState(false);
   const [mode, setMode] = useState("new");
+  const { handleSelection, handleTouchStart, handleTouchEnd } =
+    useCreateVocab();
 
   const dateKey = useMemo(
     () => selectedDate.format("YYYY-MM-DD"),
@@ -84,7 +87,15 @@ const DiaryBox = () => {
           {diary ? (
             <>
               <DiaryTitle>{diary.title}</DiaryTitle>
-              <DiaryContent variant="body1">{diary.content}</DiaryContent>
+              <DiaryContent
+                variant="body1"
+                onMouseUp={() => handleSelection(diary)}
+                onTouchStart={() => handleTouchStart(diary)}
+                onTouchEnd={handleTouchEnd}
+                style={{ whiteSpace: "pre-wrap", lineHeight: "1.6" }}
+              >
+                {diary.content}
+              </DiaryContent>
             </>
           ) : (
             <Typography variant="body1" color="text.secondary">

--- a/src/pages/VocabPage/VocabPage.jsx
+++ b/src/pages/VocabPage/VocabPage.jsx
@@ -42,7 +42,7 @@ const VocabPage = () => {
 
   return (
     <div>
-      <VocabHeader setVocabList={() => {}} />
+      {/* <VocabHeader setVocabList={() => {}} /> */}
       <div className="voca-page voca-color">
         <VocabBodyProgress
           vocabList={vocabList}


### PR DESCRIPTION
## 개요

일기에서 단어를 추출한 후 단어장을 저장하는 기능을 구현하였습니다. 

## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 단어를 더블클릭/롱프레스를 하면 단어가 선택되고 이 단어를 200ms 이상 선택 시 단어장으로 저장되는 로직을 구현하였습니다.


## 개발 후기 및 개선사항

### 이번 작업에서 배운 점
`window.getSelection()`
이 내장 함수를 통해 웹/앱 모두 같은 로직으로 처리할 수 있어 편리했습니다

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- 저장 후 뜨는 alert를 토스트 메시지로 통일할 예정입니다.
- handleSelection 가 재귀 구조로 되어있어 무한 루프에 빠지지 않게 처리는 해 두었지만 더 확인해봐야 할 것 같습니다.

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
