### PR TITLE
Fix: 스낵메시지 유지 시간 수정

### DIFF
--- a/src/common/components/GlobalSnackbar.jsx
+++ b/src/common/components/GlobalSnackbar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Snackbar, Alert } from "@mui/material";
 import useSnackbarStore from "../../stores/useSnackbarStore";
 
@@ -7,20 +7,30 @@ const GlobalSnackbar = () => {
     open,
     message,
     severity,
+    hideSnackbar,
     autoHideDuration,
     commonPosition,
-    hideSnackbar,
   } = useSnackbarStore();
 
   const isTopCenter =
     commonPosition?.vertical === "top" &&
     commonPosition?.horizontal === "center";
 
+  // 수동 타이머: open이 true가 되면 autoHideDuration 후 상태 hide
+  // 자동으로 하면 없어져버려서 수동으로 변경
+  useEffect(() => {
+    if (!open) return;
+
+    const timer = setTimeout(() => {
+      hideSnackbar();
+    }, autoHideDuration);
+
+    return () => clearTimeout(timer);
+  }, [open, autoHideDuration, hideSnackbar]);
+
   return (
     <Snackbar
       open={open}
-      autoHideDuration={autoHideDuration}
-      onClose={hideSnackbar}
       anchorOrigin={commonPosition}
       sx={(theme) => ({
         zIndex: 9000,
@@ -36,7 +46,7 @@ const GlobalSnackbar = () => {
             }),
       })}
     >
-      <Alert onClose={hideSnackbar} severity={severity} sx={{ width: "100%" }}>
+      <Alert severity={severity} onClose={hideSnackbar} sx={{ width: "100%" }}>
         {message}
       </Alert>
     </Snackbar>

--- a/src/hooks/useCreateVocab.js
+++ b/src/hooks/useCreateVocab.js
@@ -25,44 +25,47 @@ const useCreateVocab = (existingVocab = []) => {
   let pressTimer = null;
   let isDragging = false;
 
-  const saveWord = () => {
-    const selected = window.getSelection().toString().trim().toLowerCase();
-    if (!selected) return;
-    if (existingVocab.includes(selected)) {
-      showError(`이미 저장된 단어입니다: ${selected}`, 3000, {
+  const saveWord = (word) => {
+    if (!word) return;
+
+    const lowerWord = word.toLowerCase();
+    if (existingVocab.includes(lowerWord)) {
+      showError(`이미 저장된 단어입니다: ${lowerWord}`, 3000, {
         vertical: "top",
         horizontal: "center",
       });
       return;
     }
-    mutation.mutate(selected);
+
+    mutation.mutate(lowerWord);
   };
 
-  // 데스크톱 롱프레스
   const handleMouseDown = () => {
     isDragging = false;
+    const selectedWord = window.getSelection()?.toString().trim();
+    if (!selectedWord) return;
+
     pressTimer = setTimeout(() => {
-      if (!isDragging) saveWord();
-    }, 3000); // 롱프레스 판정 시간 3초
+      if (!isDragging) saveWord(selectedWord);
+    }, 3000);
   };
 
   const handleMouseMove = () => {
-    isDragging = true; // 드래그 중 저장 방지
+    isDragging = true;
   };
 
-  const handleMouseUp = () => clearTimeout(pressTimer);
+  const handleMouseUp = () => clearTimeout(pressTimer); // 상태 건드리지 않음
 
-  // 모바일 롱프레스
   const handleTouchStart = () => {
+    const selectedWord = window.getSelection()?.toString().trim();
+    if (!selectedWord) return;
+
     pressTimer = setTimeout(() => {
-      const selected = window.getSelection().toString().trim();
-      if (selected) {
-        saveWord();
-      }
-    }, 3000); // 단어 선택 후 롱프레스
+      saveWord(selectedWord);
+    }, 3000);
   };
 
-  const handleTouchEnd = () => clearTimeout(pressTimer);
+  const handleTouchEnd = () => clearTimeout(pressTimer); // 상태 건드리지 않음
 
   return {
     handleMouseDown,


### PR DESCRIPTION
## 개요

 스낵메시지 유지 시간 수정하였습니다.

## 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 롱프레스 이후 단어에서 프레스를 중지하면 토스트 메시지가 날라가는 에러가 있었습니다. 
이 경우, global snack bar 에서 시간을 자동에서 수동으로 바꾸어 삭제를 하지 않으면 3초가 유지되게 하였습니다.

- 중복 저장 시 프레스를 중지해야 토스트 메시지가 보여서 유저가 알아차리기 힘든 경우가 있었습니다.
에러 시간을 5초로 설정해 5초 이상의 프레스가 감지되면 중복 저장 확인으로 처리해 중복저장 시 중복임을 알려주고 중복이 아닌데도 에러가 있다면 다시 한 번 시도하라는 메시지를 띄웠습니다.

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- 프레스 단어 처리/ 토스트 메시지 핸들링이 한 단어의 선택 기준이다보니 그 기준을 분리해야하고, 그런 경우 상위 파일을 수정해 전역으로 변경하는 것이 방법임을 배웠습니다. 

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
