### PR TITLE
fix: 바디와 푸터 사이 공간 채우기

### DIFF
--- a/src/pages/VocabPage/VocabPage.jsx
+++ b/src/pages/VocabPage/VocabPage.jsx
@@ -158,14 +158,14 @@ const ButtonRow = styled(Box)(({ theme }) => ({
 }));
 
 const VocabPageContainer = styled(Box)(({ theme }) => ({
+  flex: 1, // 헤더/푸터 사이 공간을 자동으로 채움
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  maxHeight: "calc(100dvh - 70px)",
-  height: "100%",
+  width: "100%",
   padding: "0 6rem",
   backgroundColor: "var(--mui-palette-background-paper)",
-  overflowY: "hidden",
+  overflow: "hidden",
 
   [theme.breakpoints.down("md")]: {
     padding: "0 1rem",


### PR DESCRIPTION
## 개요

바디와 푸터 사이 공간을 채웠습니다. 

## 변경 사항

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 전체적으로 flex 1, 최대 높이를 삭제해 단어장 크기보다 배경이 많이 커져도 마진이 안 보이도록 수정하였습니다. 

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
