### PR TITLE
Fix: 버튼과 토글, 사진 위치 수정

### DIFF
--- a/src/pages/DailyPage/components/ResultsBox.jsx
+++ b/src/pages/DailyPage/components/ResultsBox.jsx
@@ -61,7 +61,6 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
   const hoursDiff = now.diff(target, "hour");
   const isEditableDay = hoursDiff <= 24;
   const canEdit = diary && isEditableDay;
-  const publicEdit = diary && !isEditableDay;
 
   const [isPublic, setIsPublic] = useState(diary.isPublic);
   const { mutate: updatePublic } = useUpdatePublicDiary();
@@ -133,6 +132,11 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
             <Typography variant="h5" sx={{ mt: 1, mb: 1, fontWeight: 900 }}>
               {diary?.title ?? ""}
             </Typography>
+            {diary?.image && (
+              <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
+                <img src={diary.image} width={160} alt="image" />
+              </Box>
+            )}
             <Typography
               sx={{ whiteSpace: "pre-line", fontSize: "16.5px" }}
               onMouseDown={handleMouseDown}
@@ -144,38 +148,37 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
             >
               {diary?.content ?? ""}
             </Typography>
-            {diary?.image && <img src={diary.image} width={120} alt="image" />}
             <Box
               sx={{
                 mt: "auto",
                 pt: 2,
                 display: "flex",
-                justifyContent: "flex-end",
                 alignItems: "center",
                 gap: 1,
               }}
             >
               {canEdit && (
-                <>
+                <Box sx={{ display: "flex", gap: 1 }}>
                   <Button
                     onClick={openEditForm}
                     variant="outlined"
-                    sx={{ ml: 1, borderColor: ACCENT, color: ACCENT }}
+                    sx={{ borderColor: ACCENT, color: ACCENT }}
                   >
-                    일기 수정하기
+                    수정
                   </Button>
                   <Button
                     onClick={deleteEntry}
                     variant="outlined"
                     color="error"
-                    sx={{ ml: 1 }}
                   >
-                    일기 삭제하기
+                    삭제
                   </Button>
-                </>
+                </Box>
               )}
-              {publicEdit && (
+
+              {diary && (
                 <FormControlLabel
+                  sx={{ marginLeft: "auto" }} // 중요! 오른쪽 끝으로 밀어줌
                   control={
                     <Switch
                       checked={isPublic}


### PR DESCRIPTION
## 개요

간단한 UI 변경

## 변경 사항

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 일기가 있다면 공개/비공개 토글 항상 띄우기
- 수정 및 삭제 버튼 크기 줄이기
- 사진 위치 제목과 본문 사이로 위치 옮기기

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
