### PR TITLE
Fix: UI 개선

### DIFF
--- a/src/pages/DailyPage/components/Calendar.jsx
+++ b/src/pages/DailyPage/components/Calendar.jsx
@@ -169,8 +169,8 @@ export default function Calendar({ compact = false, showLegend = false }) {
                   width: 12,
                   height: 12,
                   borderRadius: "50%",
-                  bgcolor: "#FFCCBC",
-                  border: "2px solid #4caf50",
+                  bgcolor: "#d32f2f",
+                  border: "2px solid #d32f2f",
                 }}
               />
               <Typography variant="body2" color="text.secondary">

--- a/src/pages/DailyPage/components/DiaryBox.jsx
+++ b/src/pages/DailyPage/components/DiaryBox.jsx
@@ -50,7 +50,21 @@ const DiaryBox = ({ displayedDateKey }) => {
         }}
       >
         <CardContent sx={{ overflowY: "auto", flexGrow: 1 }}>
-          <DiaryDate>Diary for {formatDate(displayedDateKey)}</DiaryDate>
+          <Typography
+            variant="h6"
+            fontWeight={700}
+            sx={{
+              color: ACCENT,
+              whiteSpace: "nowrap",
+              fontSize: {
+                xs: "14px", // 모바일
+                sm: "18px", // 태블릿
+                md: "20px", // 데스크탑
+              },
+            }}
+          >
+            Diary for {formatDate(displayedDateKey)}
+          </Typography>
 
           <Typography variant="body1" color="text.secondary" sx={{ mt: 1 }}>
             No Diary for this date yet.
@@ -62,7 +76,7 @@ const DiaryBox = ({ displayedDateKey }) => {
               variant="contained"
               sx={{ mt: 2, backgroundColor: ACCENT, fontWeight: 700 }}
             >
-              일기 작성하기
+              Write a Diary
             </Button>
           )}
         </CardContent>

--- a/src/pages/DailyPage/components/NewDiaryDialog.jsx
+++ b/src/pages/DailyPage/components/NewDiaryDialog.jsx
@@ -71,8 +71,10 @@ const NewDiaryDialog = ({ mode, open, onClose }) => {
       onClose?.();
       createDiary(
         {
-          title: formData.title,
-          content: formData.content,
+          title: formData.title.trim(),
+          content: formData.content
+            .replace(/\n{3,}/g, "\n\n") // 연속 3줄 이상 → 2줄로 줄임
+            .trim(),
           image: formData.image || undefined,
           isPublic: formData.isPublic,
           date: selectedDate.toISOString(),

--- a/src/pages/DailyPage/components/ResultsBox.jsx
+++ b/src/pages/DailyPage/components/ResultsBox.jsx
@@ -190,7 +190,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
                     onClick={openEditForm}
                     variant="outlined"
                     sx={{
-                      ml: 1,
+                      mr: 1,
                       borderColor: ACCENT,
                       color: ACCENT,
                       fontWeight: 700,
@@ -202,7 +202,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
                     onClick={deleteEntry}
                     variant="outlined"
                     color="error"
-                    sx={{ ml: 1, fontWeight: 700 }}
+                    sx={{ mr: 1, fontWeight: 700 }}
                   >
                     Delete
                   </Button>

--- a/src/pages/DailyPage/components/ResultsBox.jsx
+++ b/src/pages/DailyPage/components/ResultsBox.jsx
@@ -126,15 +126,42 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
               flex: 1,
             }}
           >
-            <Typography variant="h6" fontWeight={700} sx={{ color: ACCENT }}>
+            <Typography
+              variant="h6"
+              fontWeight={700}
+              sx={{
+                color: ACCENT,
+                whiteSpace: "nowrap",
+                fontSize: {
+                  xs: "14px", // 모바일
+                  sm: "18px", // 태블릿
+                  md: "20px", // 데스크탑
+                },
+              }}
+            >
               Diary for {displayStr}
             </Typography>
             <Typography variant="h5" sx={{ mt: 1, mb: 1, fontWeight: 900 }}>
               {diary?.title ?? ""}
             </Typography>
             {diary?.image && (
-              <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
-                <img src={diary.image} width={160} alt="image" />
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "center",
+                  my: 2,
+                  width: "100%",
+                }}
+              >
+                <img
+                  src={diary.image}
+                  alt="image"
+                  style={{
+                    maxWidth: "100%", // 부모 너비에 맞춤
+                    height: "auto", // 비율 유지
+                    borderRadius: "8px", // 선택: 라운딩 효과
+                  }}
+                />
               </Box>
             )}
             <Typography
@@ -183,17 +210,23 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
               )}
 
               {diary && (
-                <FormControlLabel
-                  sx={{ marginLeft: "auto" }} // 중요! 오른쪽 끝으로 밀어줌
-                  control={
-                    <Switch
-                      checked={isPublic}
-                      onChange={handleToggle}
-                      color="success"
-                    />
-                  }
-                  label={isPublic ? "공개" : "비공개"}
-                />
+                <Box
+                  sx={{
+                    marginLeft: "auto", // 오른쪽 끝으로 밀기
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                  }}
+                >
+                  <Switch
+                    checked={isPublic}
+                    onChange={handleToggle}
+                    color="success"
+                  />
+                  <Typography sx={{ fontSize: "20px" }}>
+                    {isPublic ? "🌍" : "🔒"}
+                  </Typography>
+                </Box>
               )}
             </Box>
           </CardContent>

--- a/src/pages/DailyPage/components/ResultsBox.jsx
+++ b/src/pages/DailyPage/components/ResultsBox.jsx
@@ -196,7 +196,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
                       fontWeight: 700,
                     }}
                   >
-                    수정
+                    Edit
                   </Button>
                   <Button
                     onClick={deleteEntry}
@@ -204,7 +204,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
                     color="error"
                     sx={{ ml: 1, fontWeight: 700 }}
                   >
-                    삭제
+                    Delete
                   </Button>
                 </Box>
               )}


### PR DESCRIPTION
## 개요

일기 페이지 UI 개선

## 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 이미지는 특정 width를 주지 않고, 일기 content 기준으로 width가 변경되게 만듦
- 이미지에 radius를 줘서 통일성 맞추기
- title과 content에 trim() 주기
   특히 content에는 양쪽 끝 말고도 일기 내에서도 연속 3줄 이상이라면 2줄로 줄임
<img width="584" height="334" alt="image" src="https://github.com/user-attachments/assets/fa37b3cc-c534-41aa-b61e-c8d372792ffa" />

이런 식으로 입력하더라도
<img width="446" height="118" alt="image" src="https://github.com/user-attachments/assets/968fdbbd-eb6f-4122-aa21-ab506a8207d3" />

이렇게 양쪽 끝 공백과 내부 공백까지 잡아줌
- Has Entry 색깔을 캘린더 속 일기 있다는 표시 색깔과 맞춤
- 공개 비공개 글자보단 이모지가 이쁜 거 같아서 "🌍"(공개) : "🔒"(비공개)로 변경
<img width="317" height="136" alt="image" src="https://github.com/user-attachments/assets/1401923f-d47d-437e-809f-a9d9319a5539" />

- 모바일 버전에서 이렇게 날짜가 내려오는 게 신경 쓰여서 아래와 같이 모바일에서는 크기를 줄임
<img width="284" height="99" alt="image" src="https://github.com/user-attachments/assets/e44901d7-6e8a-4e9a-b54d-1268630ae60e" />

- Result Box 날짜 부분의 크기도 위와 같이 바꿈
- 버튼(생성, 수정, 삭제)을 영어로 변경함
<img width="354" height="243" alt="image" src="https://github.com/user-attachments/assets/1643e5e1-f780-43ac-a595-8e2554551be8" />

- Edit 버튼 옆 애매한 마진 발견해서 없애줌

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁
공개 비공개 이모지로 바꿨는데 직관적으로 알아볼 수 있을 것 같나요? 원래대로 한글로 표시할지 고민입니다..!!
- (없다면 패스)
