### PR TITLE
Refactor/login 로그인 후 리디렉션 로직 개선

### DIFF
--- a/src/hooks/useLoginWithEmail.js
+++ b/src/hooks/useLoginWithEmail.js
@@ -1,11 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { loginWithEmailApi } from "../apis/authApi";
 import { useAuthStore } from "../stores/authStore";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import useSnackbarStore from "../stores/useSnackbarStore";
 
 const useLoginWithEmail = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuthStore();
   const { showSuccess, showError } = useSnackbarStore();
   const mutation = useMutation({
@@ -14,7 +15,14 @@ const useLoginWithEmail = () => {
       if (response.status === "success") {
         login({ token: response.token, user: response.user });
         showSuccess("로그인 성공!");
-        navigate("/daily");
+
+        // 리디렉션으로 온 경우 원래 페이지로, 직접 로그인 페이지에 온 경우 랜딩페이지로
+        const from = location.state?.from?.pathname;
+        if (from && from !== "/login") {
+          navigate(from, { replace: true });
+        } else {
+          navigate("/", { replace: true });
+        }
       }
     },
     onError: (error) => {

--- a/src/hooks/useLoginWithGoogle.js
+++ b/src/hooks/useLoginWithGoogle.js
@@ -1,11 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { loginWithGoogleApi } from "../apis/authApi";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
 import useSnackbarStore from "../stores/useSnackbarStore";
 
 const useLoginWithGoogle = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuthStore();
   const { showSuccess, showError } = useSnackbarStore();
   const mutation = useMutation({
@@ -14,7 +15,14 @@ const useLoginWithGoogle = () => {
       if (response.status === "success") {
         login({ token: response.token, user: response.user });
         showSuccess("로그인 성공!");
-        navigate("/daily");
+
+        // 리디렉션으로 온 경우 원래 페이지로, 직접 로그인 페이지에 온 경우 랜딩페이지로
+        const from = location.state?.from?.pathname;
+        if (from && from !== "/login") {
+          navigate(from, { replace: true });
+        } else {
+          navigate("/", { replace: true });
+        }
       }
     },
     onError: (error) => {

--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -7,15 +7,17 @@ import WhySection from "./components/WhySection";
 import FeedSection from "./components/FeedSection";
 import CallToActionSection from "./components/CallToActionSection";
 import FloatingButton from "./components/FloatingButton";
+import { useAuthStore } from "../../stores/authStore";
 
 export default function LandingPage() {
+  const isLoggedIn = useAuthStore((s) => s.isAuthed());
   return (
     <Box className="landing-root">
       <HeroSection />
       <WhySection />
       <FeedSection />
       <CallToActionSection />
-      <FloatingButton />
+      {!isLoggedIn && <FloatingButton />}
     </Box>
   );
 }

--- a/src/pages/LandingPage/components/FloatingButton.jsx
+++ b/src/pages/LandingPage/components/FloatingButton.jsx
@@ -1,17 +1,18 @@
 import { Box, Button } from "@mui/material";
-import { Link as RouterLink } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import EditNoteIcon from "@mui/icons-material/EditNote";
-import { useAuthStore } from "../../../stores/authStore";
 
 export default function FloatingButton() {
-  const isLoggedIn = useAuthStore((s) => s.isAuthed());
-  if (isLoggedIn) return null;
+  const navigate = useNavigate();
+
+  const handleStartAiary = () => {
+    navigate("/vocab");
+  };
 
   return (
     <Box className="floating-write-btn">
       <Button
-        component={RouterLink}
-        to="/login"
+        onClick={handleStartAiary}
         size="large"
         variant="contained"
         className="btn-accent round"

--- a/src/pages/LandingPage/components/HeroSection.jsx
+++ b/src/pages/LandingPage/components/HeroSection.jsx
@@ -1,14 +1,17 @@
 import { Box, Button, Container, Typography } from "@mui/material";
-import { Link as RouterLink } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import TrackChangesIcon from "@mui/icons-material/TrackChanges";
 import EditNoteIcon from "@mui/icons-material/EditNote";
-import { useAuthStore } from "../../../stores/authStore";
 
 export default function HeroSection() {
-  const isLoggedIn = useAuthStore((s) => s.isAuthed());
+  const navigate = useNavigate();
+
+  const handleStartWriting = () => {
+    navigate("/daily");
+  };
 
   return (
     <Box className="hero">
@@ -57,8 +60,7 @@ export default function HeroSection() {
 
           <Box className="hero-cta">
             <Button
-              component={RouterLink}
-              to={isLoggedIn ? "/daily" : "/login"}
+              onClick={handleStartWriting}
               size="large"
               variant="contained"
               className="btn-primary"

--- a/src/routes/PrivateRoute.jsx
+++ b/src/routes/PrivateRoute.jsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
 
 const PrivateRoute = () => {
   const isLoggedIn = useAuthStore((s) => s.isAuthed());
+  const location = useLocation();
 
   if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   return <Outlet />;


### PR DESCRIPTION

## 개요

로그인 후 리디렉션 로직을 개선하여 사용자 경험을 향상시켰습니다. 기존에는 로그인 성공 시 항상 다이어리 페이지로 이동했지만, 이제는 사용자가 원래 가려던 페이지로 자연스럽게 이동할 수 있습니다.

## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 구현 내용

- **PrivateRoute 개선**: 리디렉션 시 원래 경로 정보를 `location.state`에 저장하도록 수정
- **로그인 훅 수정**: `useLoginWithEmail`, `useLoginWithGoogle`에서 리디렉션 로직 추가
  - 리디렉션으로 온 경우: 원래 가려던 페이지로 이동
  - 직접 로그인한 경우: 랜딩페이지로 이동
- **랜딩페이지 버튼 단순화**: `HeroSection`, `FloatingButton`에서 로그인 상태 체크 제거
- **네비게이션 로직 개선**: `useNavigate`를 사용하여 더 깔끔한 코드 구조로 변경

## 개발 후기 및 개선사항
### 이번 작업에서 배운 점
- React Router의 `location.state`를 활용한 리디렉션 처리 방법
- 보호된 라우트에서 인증 로직을 중앙화하여 코드 중복을 줄이는 방법

### 어려웠던 점 / 에로사항

### 다음에 개선하고 싶은 점

### 팀원들과 공유하고 싶은 팁
- 기존에 랜딩페이지에서 사용하던 로그인 확인 후 이동하는 로직 삭제 후
- useNavigate 사용으로 변경하였습니다.

랜딩페이지 '내 일기 작성하기' 비 로그인 -> 로그인페이지 -> 로그인성공 -> 다이어리페이지
랜딩페이지 플로팅버튼 'Aiary 시작하기' 비로그인 -> 로그인페이지 -> 로그인성공 -> 랜딩페이지
랜딩페이지 '일기더보기'버튼 비 로그인 ->로그인페이지 -> 로그인성공 -> 모든일기 페이지

모든 네비게이션 버튼에 비로그인유저 클릭시 원래 가려고 했던 페이지로 리디렉션 하도록 수정하였습니다.
관련하여 랜딩페이지 현진님이 작업하셨던 코드에 일부 수정이 있었습니다.
확인 부탁드립니다!
