### PR TITLE
fix: 롱프레스 시간 수정 3초5초-> 2초3초

### DIFF
--- a/src/hooks/useCreateVocab.js
+++ b/src/hooks/useCreateVocab.js
@@ -23,7 +23,7 @@ const useCreateVocab = (existingVocab = []) => {
   });
 
   let pressTimer = null;
-  let errorTimer = null; // 5초 카운트
+  let errorTimer = null; // 3초 카운트
   let isDragging = false;
 
   const saveWord = (word) => {
@@ -46,22 +46,22 @@ const useCreateVocab = (existingVocab = []) => {
     const selectedWord = window.getSelection()?.toString().trim();
     if (!selectedWord) return;
 
-    // 3초 후 롱프레스 성공
+    // 2초 후 롱프레스 성공
     pressTimer = setTimeout(() => {
       if (!isDragging) {
         saveWord(selectedWord);
         clearTimeout(errorTimer); // 실패 타이머 취소
       }
-    }, 3000);
+    }, 2000);
 
-    // 5초 후 롱프레스 실패 -> 에러 메시지
+    // 3초 후 롱프레스 실패 -> 에러 메시지
     errorTimer = setTimeout(() => {
       showError("단어를 다시 한 번 선택해 주세요.", 3000, {
         vertical: "top",
         horizontal: "center",
       });
       clearTimeout(pressTimer); // 성공 타이머 취소
-    }, 5000);
+    }, 3000);
   };
 
   const handlePressMove = () => {

--- a/src/pages/VocabPage/VocabPage.jsx
+++ b/src/pages/VocabPage/VocabPage.jsx
@@ -48,6 +48,7 @@ const VocabPage = () => {
 
   const navigate = useNavigate();
 
+  //사용자 이름 인식 단어
   const { user } = useAuthStore(); // 유저 정보
   const username = user?.name || "사용자";
 


### PR DESCRIPTION
## 개요

롱프레스 성공 시간을 3초에서 2초, 실패시간을 5초에서 3초로 변경하였습니다.

## 변경 사항

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

`// 2초 후 롱프레스 성공
    pressTimer = setTimeout(() => {
      if (!isDragging) {
        saveWord(selectedWord);
        clearTimeout(errorTimer); // 실패 타이머 취소
      }
    }, 2000);
;`
- 시간을 3000(3초)에서 2000(2초)로 수정하였습니다.

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
