### PR TITLE
Feat: 삭제 모달 생성 및 1000자 제한

### DIFF
--- a/src/pages/DailyPage/components/DeleteConfirmDialog.jsx
+++ b/src/pages/DailyPage/components/DeleteConfirmDialog.jsx
@@ -1,0 +1,55 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from "@mui/material";
+
+const DeleteConfirmDialog = ({ open, onClose, onConfirm }) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          //   top: "-200px",
+          //   position: "relative",
+          borderRadius: 3,
+          boxShadow: 4,
+          border: "2px solid",
+          borderColor: "success.light",
+          p: 1,
+        },
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 700 }}>Delete Entry</DialogTitle>
+      <DialogContent>
+        <Typography>
+          Are you sure you want to delete this diary entry?
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          color="success"
+          variant="outlined"
+          sx={{ fontWeight: 700 }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color="error"
+          variant="outlined"
+          sx={{ fontWeight: 700 }}
+        >
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteConfirmDialog;

--- a/src/pages/DailyPage/components/NewDiaryDialog.jsx
+++ b/src/pages/DailyPage/components/NewDiaryDialog.jsx
@@ -16,6 +16,7 @@ import useSnackbarStore from "../../../stores/useSnackbarStore";
 import { useUpdateDiary } from "../../../hooks/useUpdateDiary";
 
 const ACCENT = "#00BE83";
+const MAX_LENGTH = 1000;
 
 const NewDiaryDialog = ({ mode, open, onClose }) => {
   const { selectedDate, diariesByDate } = useDiaryStore();
@@ -110,7 +111,10 @@ const NewDiaryDialog = ({ mode, open, onClose }) => {
 
   const handleChange = (event) => {
     const { id, value } = event.target;
-    setFormData((prev) => ({ ...prev, [id]: value }));
+    setFormData((prev) => ({
+      ...prev,
+      [id]: id === "content" ? value.slice(0, MAX_LENGTH) : value, // content만 제한
+    }));
   };
 
   const uploadImage = (url) => {
@@ -156,7 +160,7 @@ const NewDiaryDialog = ({ mode, open, onClose }) => {
             margin="normal"
             value={formData.title}
             onChange={handleChange}
-            input={{ maxLength: 60 }}
+            inputProps={{ maxLength: 60 }}
             InputLabelProps={{
               sx: {
                 "&.Mui-focused": { color: ACCENT }, // 포커스 시 라벨만 악센트
@@ -179,6 +183,7 @@ const NewDiaryDialog = ({ mode, open, onClose }) => {
             rows={6}
             value={formData.content}
             onChange={handleChange}
+            inputProps={{ maxLength: MAX_LENGTH }}
             InputLabelProps={{
               sx: {
                 "&.Mui-focused": { color: ACCENT }, // 포커스 시 라벨만 악센트
@@ -191,6 +196,7 @@ const NewDiaryDialog = ({ mode, open, onClose }) => {
                 "&.Mui-focused fieldset": { borderColor: ACCENT },
               },
             }}
+            helperText={`${formData.content.length} / ${MAX_LENGTH} characters`} // 카운트 표시
           />
           <FormControlLabel
             sx={{ mt: 1 }}

--- a/src/pages/DailyPage/components/ResultsBox.jsx
+++ b/src/pages/DailyPage/components/ResultsBox.jsx
@@ -19,6 +19,7 @@ import React, { useState } from "react";
 import NewDiaryDialog from "./NewDiaryDialog";
 import useDeleteDiary from "../../../hooks/useDeleteDiary";
 import { useUpdatePublicDiary } from "../../../hooks/useUpdatePublicDiary";
+import DeleteConfirmDialog from "./DeleteConfirmDialog";
 
 const ACCENT = "#00BE83";
 
@@ -46,6 +47,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
   const { mutate: deleteDiaryMutate } = useDeleteDiary();
 
   const [openDialog, setOpenDialog] = useState(false);
+  const [open, setOpen] = useState(false);
   const [mode, setMode] = useState("edit");
 
   const formatDateKey = (dk) =>
@@ -88,6 +90,7 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
       year,
       month,
     });
+    setOpen(false);
   };
 
   const displayStr =
@@ -199,13 +202,18 @@ const ResultsBox = ({ diary, displayedDateKey }) => {
                     Edit
                   </Button>
                   <Button
-                    onClick={deleteEntry}
+                    onClick={() => setOpen(true)}
                     variant="outlined"
                     color="error"
                     sx={{ mr: 1, fontWeight: 700 }}
                   >
                     Delete
                   </Button>
+                  <DeleteConfirmDialog
+                    open={open}
+                    onClose={() => setOpen(false)}
+                    onConfirm={deleteEntry}
+                  />
                 </Box>
               )}
 


### PR DESCRIPTION
## 개요

이 PR의 목적과 구현 내용을 간단히 설명합니다.

## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

- 삭제 시 한 번 더 물어보게 삭제 모달 생성
- 일기 생성 시 content 1000자 제한
- "현재 작성한 글자 수 / 1000자"로 유저들이 자신이 얼마큼 썼는지 확인 가능
- 일기 제목도 60자 제한이 있었는데 문법 잘못되어 있어서 고쳤음
input이 아닌 inputProps로 글자 수 제한 가능 예) inputPros={{ maxLength: 60 }}

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
